### PR TITLE
Fix measurement readings and refactor API

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ let i2c = ...; // I2C bus to use
 
 let mut device = Ens160::new(i2c);
 device.reset().unwrap();
+sleep(250)
+device.operational().unwrap();
+sleep(50)
 
 loop {
     if let Ok(status) = device.status() {

--- a/README.md
+++ b/README.md
@@ -15,10 +15,20 @@ For more information about the sensor [here](https://wiki.dfrobot.com/SKU_SEN051
 let i2c = ...; // I2C bus to use
 
 let mut device = Ens160::new(i2c);
-let tvoc = device.get_tvoc().unwrap();
-let eco2 = device.get_eco2().unwrap();
+device.reset().unwrap();
 
-let airquality_index = AirqualityIndex::try_from(eco2).unwrap();
+loop {
+    if let Ok(status) = device.status() {
+        if status.data_is_ready() {
+            let tvoc = device.tvoc().unwrap();
+            let eco2 = device.eco2().unwrap();
+            // from eCO2
+            let airquality_index = AirqualityIndex::try_from(eco2).unwrap();
+            // directly
+            let airquality_index = device.airquality_index().unwrap();
+        }
+    }
+}
 
 let i2c = device.release(); // destruct driver to use bus with other drivers
 ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@ use core::{
     ops::{Deref, DerefMut},
 };
 
-use embedded_hal::blocking::i2c::{Read, Write, WriteRead};
+use embedded_hal::blocking::i2c::{Write, WriteRead};
 
 use bitfield::bitfield;
 use error::AirqualityConvError;
@@ -72,7 +72,7 @@ impl<I2C> Ens160<I2C> {
 
 impl<I2C, E> Ens160<I2C>
 where
-    I2C: WriteRead<Error = E> + Write<Error = E> + Read<Error = E>,
+    I2C: WriteRead<Error = E> + Write<Error = E>,
 {
     /// Resets the device.
     pub fn reset(&mut self) -> Result<(), E> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,6 +79,13 @@ where
         self.write_register([ENS160_OPMODE_REG, OperationMode::Reset as u8])
     }
 
+    /// Switches the device to idle mode.
+    ///
+    /// Only in idle mode operations with `ENS160_COMMAND_REG` can be performed.
+    pub fn idle(&mut self) -> Result<(), E> {
+        self.write_register([ENS160_OPMODE_REG, OperationMode::Idle as u8])
+    }
+
     /// Switches the device to deep sleep mode.
     ///
     /// This function can be used to conserve power when the device is not in use.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@ use core::{
     ops::{Deref, DerefMut},
 };
 
-use embedded_hal::blocking::i2c::{Write, WriteRead};
+use embedded_hal::blocking::i2c::{Read, Write, WriteRead};
 
 use bitfield::bitfield;
 use error::AirqualityConvError;
@@ -72,77 +72,119 @@ impl<I2C> Ens160<I2C> {
 
 impl<I2C, E> Ens160<I2C>
 where
-    I2C: WriteRead<Error = E> + Write<Error = E>,
+    I2C: WriteRead<Error = E> + Write<Error = E> + Read<Error = E>,
 {
-    /// Returns the sensors part id.
-    pub fn get_part_id(&mut self) -> Result<u16, E> {
+    /// Resets the device.
+    pub fn reset(&mut self) -> Result<(), E> {
+        self.write_register([ENS160_OPMODE_REG, OperationMode::Reset as u8])
+    }
+
+    /// Switches the device to deep sleep mode.
+    ///
+    /// This function can be used to conserve power when the device is not in use.
+    pub fn deep_sleep(&mut self) -> Result<(), E> {
+        self.write_register([ENS160_OPMODE_REG, OperationMode::Sleep as u8])
+    }
+
+    /// Switches the device to operational mode.
+    ///
+    /// Call this function when you want the device to start taking measurements.
+    pub fn operational(&mut self) -> Result<(), E> {
+        self.write_register([ENS160_OPMODE_REG, OperationMode::Standard as u8])
+    }
+
+    /// Clears the command register of the device.
+    pub fn clear_command(&mut self) -> Result<(), E> {
+        self.write_register([ENS160_COMMAND_REG, Command::Nop as u8])?;
+        self.write_register([ENS160_COMMAND_REG, Command::Clear as u8])?;
+        Ok(())
+    }
+
+    /// Returns the part ID of the sensor.
+    pub fn part_id(&mut self) -> Result<u16, E> {
         self.read_register::<2>(ENS160_PART_ID_REG)
-            .map(u16::from_be_bytes)
+            .map(u16::from_le_bytes)
+    }
+
+    /// Returns the firmware version of the sensor.
+    pub fn firmware_version(&mut self) -> Result<(u8, u8, u8), E> {
+        self.write_register([ENS160_COMMAND_REG, Command::GetAppVersion as u8])?;
+        let buffer = self.read_register::<3>(ENS160_GPR_READ_REG)?;
+        Ok((buffer[0], buffer[1], buffer[2]))
     }
 
     /// Returns the current status of the sensor.
-    pub fn get_status(&mut self) -> Result<Status, E> {
+    pub fn status(&mut self) -> Result<Status, E> {
         self.read_register::<1>(ENS160_DATA_STATUS_REG)
             .map(|v| Status(v[0]))
     }
 
-    /// Returns an index of airquality related to the current measures.
-    pub fn get_airquality_index(&mut self) -> Result<AirqualityIndex, E> {
+    /// Returns the current Air Quality Index (AQI) reading from the sensor.
+    ///
+    /// The AQI is calculated based on the current sensor readings.
+    pub fn airquality_index(&mut self) -> Result<AirqualityIndex, E> {
         self.read_register::<1>(ENS160_DATA_AQI_REG)
-            .map(|v| v[0].into())
+            .map(|v| AirqualityIndex::from(v[0] & 0x07))
     }
 
-    /// Get tvoc measures in `ppb` in range `0-65000`.
-    pub fn get_tvoc(&mut self) -> Result<u16, E> {
+    /// Returns the Total Volatile Organic Compounds (TVOC) measurement from the sensor.
+    ///
+    /// The TVOC level is expressed in parts per billion (ppb) in the range 0-65000.
+    pub fn tvoc(&mut self) -> Result<u16, E> {
         self.read_register::<2>(ENS160_DATA_TVOC_REG)
-            .map(u16::from_be_bytes)
+            .map(u16::from_le_bytes)
     }
 
-    /// Get eco2 measures in `ppm` in range `400-65000`.
-    pub fn get_eco2(&mut self) -> Result<ECo2, E> {
+    /// Returns the Equivalent Carbon Dioxide (eCO2) measurement from the sensor.
+    ///
+    /// The eCO2 level is expressed in parts per million (ppm) in the range 400-65000.
+    pub fn eco2(&mut self) -> Result<ECo2, E> {
         self.read_register::<2>(ENS160_DATA_ECO2_REG)
-            .map(u16::from_be_bytes)
+            .map(u16::from_le_bytes)
             .map(ECo2::from)
     }
 
-    /// Returns the previous set temperature and humidity.
+    /// Returns the temperature (in °C) and relative humidity (in %) values used in the calculations.
     ///
-    /// Values can be set with [`Ens160::set_temp_and_hum()`].
-    pub fn get_temp_and_hum(&mut self) -> Result<(f32, f32), E> {
+    /// The units are scaled by 100. For example, a temperature value of 2550 represents 25.50 °C,
+    /// and a humidity value of 5025 represents 50.25% RH.
+    ///
+    /// These values can be set using [`Ens160::set_temp_and_hum()`].
+    pub fn temp_and_hum(&mut self) -> Result<(u16, u16), E> {
         let buffer = self.read_register::<4>(ENS160_DATA_T_REG)?;
-        let temp = u16::from_be_bytes([buffer[0], buffer[1]]);
-        let rh = u16::from_be_bytes([buffer[2], buffer[3]]);
+        let temp = u16::from_le_bytes([buffer[0], buffer[1]]);
+        let rh = u16::from_le_bytes([buffer[2], buffer[3]]);
 
-        let temp = ((temp as f32) - 0.5) / 64.0 - 273.15;
-        let hum = ((rh as f32) - 0.5) / 512.0;
+        let temp = temp as u32 * 100 / 64 - 27315;
+        let hum = rh as u32 * 100 / 512;
 
-        Ok((temp, hum))
+        Ok((temp as u16, hum as u16))
     }
 
-    /// Sets the opration mode of the sensor.
-    pub fn set_operation_mode(&mut self, mode: OperationMode) -> Result<(), E> {
-        self.write_register([ENS160_OPMODE_REG, mode as u8])
-    }
-
-    /// Sets the interrupt configuration.
-    pub fn set_interrupt_config(&mut self, config: InterruptConfig) -> Result<(), E> {
-        self.write_register([ENS160_CONFIG_REG, config.finish().0])
-    }
-
-    /// Sets the temperature (°C) and humidity (%rh (relative Humidity in percent)) for calculations.
-    pub fn set_temp_and_hum(&mut self, ambient_temp: f32, relative_humidity: f32) -> Result<(), E> {
-        let temp = ((ambient_temp + 273.15) * 64.0 + 0.5) as u16;
-        let rh = (relative_humidity * 512.0 + 0.5) as u16;
+    /// Sets the temperature and relative humidity values used in the device's calculations.
+    ///
+    /// The units are scaled by 100. For example, a temperature value of 2550 should be used for 25.50 °C,
+    /// and a humidity value of 5025 for 50.25% RH.
+    pub fn set_temp_and_hum(&mut self, ambient_temp: u16, relative_humidity: u16) -> Result<(), E> {
+        let temp = ((ambient_temp as u32 + 27315) * 64 / 100) as u16;
+        let rh = (relative_humidity as u32 * 512 / 100) as u16;
 
         let temp = temp.to_le_bytes();
         let rh = rh.to_le_bytes();
 
-        let buffer = [ENS160_TEMP_IN_REG, temp[0], temp[1], rh[0], rh[1]];
-        self.write_register(buffer)
+        let tbuffer = [ENS160_TEMP_IN_REG, temp[0], temp[1]];
+        let hbuffer = [ENS160_RH_IN_REG, rh[0], rh[1]];
+        self.write_register(tbuffer)?;
+        self.write_register(hbuffer)
+    }
+
+    /// Sets interrupt configuration.
+    pub fn set_interrupt_config(&mut self, config: InterruptConfig) -> Result<(), E> {
+        self.write_register([ENS160_CONFIG_REG, config.finish().0])
     }
 
     fn read_register<const N: usize>(&mut self, register: u8) -> Result<[u8; N], E> {
-        let mut write_buffer = [0u8; N];
+        let mut write_buffer = [0u8; 1];
         write_buffer[0] = register;
         let mut buffer = [0u8; N];
         self.i2c
@@ -155,15 +197,28 @@ where
     }
 }
 
+/// Commands for ENS160_COMMAND_REG.
+#[repr(u8)]
+enum Command {
+    /// No operation
+    Nop = 0x00,
+    /// Get FW version
+    GetAppVersion = 0x0E,
+    /// Clears GPR Read Registers
+    Clear = 0xCC,
+}
+
 /// Operation Mode of the sensor.
 #[repr(u8)]
-pub enum OperationMode {
+enum OperationMode {
     /// DEEP SLEEP mode (low power standby).
     Sleep = 0x00,
     /// IDLE mode (low-power).
     Idle = 0x01,
     /// STANDARD Gas Sensing Modes.
     Standard = 0x02,
+    /// Reset device.
+    Reset = 0xF0,
 }
 
 bitfield! {
@@ -290,44 +345,25 @@ impl InterruptConfig {
     }
 }
 
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[repr(u8)]
 pub enum AirqualityIndex {
-    Excellent = 0x1,
-    Good = 0x2,
-    Moderate = 0x3,
-    Poor = 0x4,
-    Unhealthy = 0x5,
-}
-
-impl PartialOrd for AirqualityIndex {
-    fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
-        use core::cmp::Ordering;
-        let self_index = *self as u8;
-        let other_index = *other as u8;
-        Some(match self_index.cmp(&other_index) {
-            Ordering::Less => Ordering::Greater,
-            Ordering::Greater => Ordering::Less,
-            _ => Ordering::Equal,
-        })
-    }
-}
-
-impl Ord for AirqualityIndex {
-    fn cmp(&self, other: &Self) -> core::cmp::Ordering {
-        self.partial_cmp(other).unwrap()
-    }
+    Excellent = 1,
+    Good = 2,
+    Moderate = 3,
+    Poor = 4,
+    Unhealthy = 5,
 }
 
 impl From<u8> for AirqualityIndex {
     fn from(i: u8) -> Self {
         match i {
-            0x01 => Self::Excellent,
-            0x02 => Self::Good,
-            0x03 => Self::Moderate,
-            0x04 => Self::Poor,
-            0x05 => Self::Unhealthy,
-            _ => unimplemented!(),
+            1 => Self::Excellent,
+            2 => Self::Good,
+            3 => Self::Moderate,
+            4 => Self::Poor,
+            5 => Self::Unhealthy,
+            _ => Self::Unhealthy,
         }
     }
 }


### PR DESCRIPTION
This PR addresses several improvements and fixes:

1. Corrects an issue with reading measurements from the sensor, which previously provided incorrect readings due to endianness bugs in the original code.

2. Replaces `f32` based temperature and humidity settings with scaled `u16`. This change is aimed at improving convenience and efficiency on small microcontrollers.

I have carefully tested these changes to ensure accurate sensor readings.