### PR TITLE
Remove duplicate code with `maybe_async_cfg`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,4 @@ async = ["dep:embedded-hal-async"]
 embedded-hal = "1.0.0-rc.3"
 embedded-hal-async = { version = "=1.0.0-rc.3", optional = true }
 bitfield = "0.14.0"
+maybe-async-cfg = "0.2.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@ use core::{
 #[cfg(not(feature = "async"))]
 use embedded_hal::i2c::I2c;
 #[cfg(feature = "async")]
-use embedded_hal_async::i2c::I2c;
+use embedded_hal_async::i2c::I2c as AsyncI2c;
 
 use bitfield::bitfield;
 use error::AirqualityConvError;
@@ -73,18 +73,20 @@ impl<I2C> Ens160<I2C> {
     }
 }
 
+#[maybe_async_cfg::maybe(
+    sync(
+        cfg(not(feature = "async")),
+        self = "Ens160",
+        idents(AsyncI2c(sync = "I2c"))
+    ),
+    async(feature = "async", keep_self)
+)]
+
 impl<I2C, E> Ens160<I2C>
 where
-    I2C: I2c<Error = E>,
+    I2C: AsyncI2c<Error = E>,
 {
     /// Resets the device.
-    #[cfg(not(feature = "async"))]
-    pub fn reset(&mut self) -> Result<(), E> {
-        self.write_register([ENS160_OPMODE_REG, OperationMode::Reset as u8])
-    }
-
-    /// Resets the device.
-    #[cfg(feature = "async")]
     pub async fn reset(&mut self) -> Result<(), E> {
         self.write_register([ENS160_OPMODE_REG, OperationMode::Reset as u8])
             .await
@@ -93,15 +95,6 @@ where
     /// Switches the device to idle mode.
     ///
     /// Only in idle mode operations with `ENS160_COMMAND_REG` can be performed.
-    #[cfg(not(feature = "async"))]
-    pub fn idle(&mut self) -> Result<(), E> {
-        self.write_register([ENS160_OPMODE_REG, OperationMode::Idle as u8])
-    }
-
-    /// Switches the device to idle mode.
-    ///
-    /// Only in idle mode operations with `ENS160_COMMAND_REG` can be performed.
-    #[cfg(feature = "async")]
     pub async fn idle(&mut self) -> Result<(), E> {
         self.write_register([ENS160_OPMODE_REG, OperationMode::Idle as u8])
             .await
@@ -110,15 +103,6 @@ where
     /// Switches the device to deep sleep mode.
     ///
     /// This function can be used to conserve power when the device is not in use.
-    #[cfg(not(feature = "async"))]
-    pub fn deep_sleep(&mut self) -> Result<(), E> {
-        self.write_register([ENS160_OPMODE_REG, OperationMode::Sleep as u8])
-    }
-
-    /// Switches the device to deep sleep mode.
-    ///
-    /// This function can be used to conserve power when the device is not in use.
-    #[cfg(feature = "async")]
     pub async fn deep_sleep(&mut self) -> Result<(), E> {
         self.write_register([ENS160_OPMODE_REG, OperationMode::Sleep as u8])
             .await
@@ -127,30 +111,12 @@ where
     /// Switches the device to operational mode.
     ///
     /// Call this function when you want the device to start taking measurements.
-    #[cfg(not(feature = "async"))]
-    pub fn operational(&mut self) -> Result<(), E> {
-        self.write_register([ENS160_OPMODE_REG, OperationMode::Standard as u8])
-    }
-
-    /// Switches the device to operational mode.
-    ///
-    /// Call this function when you want the device to start taking measurements.
-    #[cfg(feature = "async")]
     pub async fn operational(&mut self) -> Result<(), E> {
         self.write_register([ENS160_OPMODE_REG, OperationMode::Standard as u8])
             .await
     }
 
     /// Clears the command register of the device.
-    #[cfg(not(feature = "async"))]
-    pub fn clear_command(&mut self) -> Result<(), E> {
-        self.write_register([ENS160_COMMAND_REG, Command::Nop as u8])?;
-        self.write_register([ENS160_COMMAND_REG, Command::Clear as u8])?;
-        Ok(())
-    }
-
-    /// Clears the command register of the device.
-    #[cfg(feature = "async")]
     pub async fn clear_command(&mut self) -> Result<(), E> {
         self.write_register([ENS160_COMMAND_REG, Command::Nop as u8])
             .await?;
@@ -160,14 +126,6 @@ where
     }
 
     /// Returns the part ID of the sensor.
-    #[cfg(not(feature = "async"))]
-    pub fn part_id(&mut self) -> Result<u16, E> {
-        self.read_register::<2>(ENS160_PART_ID_REG)
-            .map(u16::from_le_bytes)
-    }
-
-    /// Returns the part ID of the sensor.
-    #[cfg(feature = "async")]
     pub async fn part_id(&mut self) -> Result<u16, E> {
         self.read_register::<2>(ENS160_PART_ID_REG)
             .await
@@ -175,15 +133,6 @@ where
     }
 
     /// Returns the firmware version of the sensor.
-    #[cfg(not(feature = "async"))]
-    pub fn firmware_version(&mut self) -> Result<(u8, u8, u8), E> {
-        self.write_register([ENS160_COMMAND_REG, Command::GetAppVersion as u8])?;
-        let buffer = self.read_register::<3>(ENS160_GPR_READ_REG)?;
-        Ok((buffer[0], buffer[1], buffer[2]))
-    }
-
-    /// Returns the firmware version of the sensor.
-    #[cfg(feature = "async")]
     pub async fn firmware_version(&mut self) -> Result<(u8, u8, u8), E> {
         self.write_register([ENS160_COMMAND_REG, Command::GetAppVersion as u8])
             .await?;
@@ -192,14 +141,6 @@ where
     }
 
     /// Returns the current status of the sensor.
-    #[cfg(not(feature = "async"))]
-    pub fn status(&mut self) -> Result<Status, E> {
-        self.read_register::<1>(ENS160_DATA_STATUS_REG)
-            .map(|v| Status(v[0]))
-    }
-
-    /// Returns the current status of the sensor.
-    #[cfg(feature = "async")]
     pub async fn status(&mut self) -> Result<Status, E> {
         self.read_register::<1>(ENS160_DATA_STATUS_REG)
             .await
@@ -209,16 +150,6 @@ where
     /// Returns the current Air Quality Index (AQI) reading from the sensor.
     ///
     /// The AQI is calculated based on the current sensor readings.
-    #[cfg(not(feature = "async"))]
-    pub fn airquality_index(&mut self) -> Result<AirqualityIndex, E> {
-        self.read_register::<1>(ENS160_DATA_AQI_REG)
-            .map(|v| AirqualityIndex::from(v[0] & 0x07))
-    }
-
-    /// Returns the current Air Quality Index (AQI) reading from the sensor.
-    ///
-    /// The AQI is calculated based on the current sensor readings.
-    #[cfg(feature = "async")]
     pub async fn airquality_index(&mut self) -> Result<AirqualityIndex, E> {
         self.read_register::<1>(ENS160_DATA_AQI_REG)
             .await
@@ -228,16 +159,6 @@ where
     /// Returns the Total Volatile Organic Compounds (TVOC) measurement from the sensor.
     ///
     /// The TVOC level is expressed in parts per billion (ppb) in the range 0-65000.
-    #[cfg(not(feature = "async"))]
-    pub fn tvoc(&mut self) -> Result<u16, E> {
-        self.read_register::<2>(ENS160_DATA_TVOC_REG)
-            .map(u16::from_le_bytes)
-    }
-
-    /// Returns the Total Volatile Organic Compounds (TVOC) measurement from the sensor.
-    ///
-    /// The TVOC level is expressed in parts per billion (ppb) in the range 0-65000.
-    #[cfg(feature = "async")]
     pub async fn tvoc(&mut self) -> Result<u16, E> {
         self.read_register::<2>(ENS160_DATA_TVOC_REG)
             .await
@@ -247,17 +168,6 @@ where
     /// Returns the Equivalent Carbon Dioxide (eCO2) measurement from the sensor.
     ///
     /// The eCO2 level is expressed in parts per million (ppm) in the range 400-65000.
-    #[cfg(not(feature = "async"))]
-    pub fn eco2(&mut self) -> Result<ECo2, E> {
-        self.read_register::<2>(ENS160_DATA_ECO2_REG)
-            .map(u16::from_le_bytes)
-            .map(ECo2::from)
-    }
-
-    /// Returns the Equivalent Carbon Dioxide (eCO2) measurement from the sensor.
-    ///
-    /// The eCO2 level is expressed in parts per million (ppm) in the range 400-65000.
-    #[cfg(feature = "async")]
     pub async fn eco2(&mut self) -> Result<ECo2, E> {
         self.read_register::<2>(ENS160_DATA_ECO2_REG)
             .await
@@ -271,25 +181,6 @@ where
     /// and a humidity value of 5025 represents 50.25% RH.
     ///
     /// These values can be set using [`Ens160::set_temp_and_hum()`].
-    #[cfg(not(feature = "async"))]
-    pub fn temp_and_hum(&mut self) -> Result<(i16, u16), E> {
-        let buffer = self.read_register::<4>(ENS160_DATA_T_REG)?;
-        let temp = u16::from_le_bytes([buffer[0], buffer[1]]);
-        let rh = u16::from_le_bytes([buffer[2], buffer[3]]);
-
-        let temp = temp as i32 * 100 / 64 - 27315;
-        let hum = rh as u32 * 100 / 512;
-
-        Ok((temp as i16, hum as u16))
-    }
-
-    /// Returns the temperature (in °C) and relative humidity (in %) values used in the calculations.
-    ///
-    /// The units are scaled by 100. For example, a temperature value of 2550 represents 25.50 °C,
-    /// and a humidity value of 5025 represents 50.25% RH.
-    ///
-    /// These values can be set using [`Ens160::set_temp_and_hum()`].
-    #[cfg(feature = "async")]
     pub async fn temp_and_hum(&mut self) -> Result<(i16, u16), E> {
         let buffer = self.read_register::<4>(ENS160_DATA_T_REG).await?;
         let temp = u16::from_le_bytes([buffer[0], buffer[1]]);
@@ -304,18 +195,6 @@ where
     /// Sets the temperature value used in the device's calculations.
     ///
     /// Unit is scaled by 100. For example, a temperature value of 2550 should be used for 25.50 °C.
-    #[cfg(not(feature = "async"))]
-    pub fn set_temp(&mut self, ambient_temp: i16) -> Result<(), E> {
-        let temp = ((ambient_temp as i32 + 27315) * 64 / 100) as u16;
-        let temp = temp.to_le_bytes();
-        let tbuffer = [ENS160_TEMP_IN_REG, temp[0], temp[1]];
-        self.write_register(tbuffer)
-    }
-
-    /// Sets the temperature value used in the device's calculations.
-    ///
-    /// Unit is scaled by 100. For example, a temperature value of 2550 should be used for 25.50 °C.
-    #[cfg(feature = "async")]
     pub async fn set_temp(&mut self, ambient_temp: i16) -> Result<(), E> {
         let temp = ((ambient_temp as i32 + 27315) * 64 / 100) as u16;
         let temp = temp.to_le_bytes();
@@ -326,18 +205,6 @@ where
     /// Sets the relative humidity value used in the device's calculations.
     ///
     /// Unit is scaled by 100. For example, a humidity value of 5025 should be used for 50.25% RH.
-    #[cfg(not(feature = "async"))]
-    pub fn set_hum(&mut self, relative_humidity: u16) -> Result<(), E> {
-        let rh = (relative_humidity as u32 * 512 / 100) as u16;
-        let rh = rh.to_le_bytes();
-        let hbuffer = [ENS160_RH_IN_REG, rh[0], rh[1]];
-        self.write_register(hbuffer)
-    }
-
-    /// Sets the relative humidity value used in the device's calculations.
-    ///
-    /// Unit is scaled by 100. For example, a humidity value of 5025 should be used for 50.25% RH.
-    #[cfg(feature = "async")]
     pub async fn set_hum(&mut self, relative_humidity: u16) -> Result<(), E> {
         let rh = (relative_humidity as u32 * 512 / 100) as u16;
         let rh = rh.to_le_bytes();
@@ -346,29 +213,11 @@ where
     }
 
     /// Sets interrupt configuration.
-    #[cfg(not(feature = "async"))]
-    pub fn set_interrupt_config(&mut self, config: InterruptConfig) -> Result<(), E> {
-        self.write_register([ENS160_CONFIG_REG, config.finish().0])
-    }
-
-    /// Sets interrupt configuration.
-    #[cfg(feature = "async")]
     pub async fn set_interrupt_config(&mut self, config: InterruptConfig) -> Result<(), E> {
         self.write_register([ENS160_CONFIG_REG, config.finish().0])
             .await
     }
 
-    #[cfg(not(feature = "async"))]
-    fn read_register<const N: usize>(&mut self, register: u8) -> Result<[u8; N], E> {
-        let mut write_buffer = [0u8; 1];
-        write_buffer[0] = register;
-        let mut buffer = [0u8; N];
-        self.i2c
-            .write_read(self.address, &write_buffer, &mut buffer)?;
-        Ok(buffer)
-    }
-
-    #[cfg(feature = "async")]
     async fn read_register<const N: usize>(&mut self, register: u8) -> Result<[u8; N], E> {
         let mut write_buffer = [0u8; 1];
         write_buffer[0] = register;
@@ -379,12 +228,6 @@ where
         Ok(buffer)
     }
 
-    #[cfg(not(feature = "async"))]
-    fn write_register<const N: usize>(&mut self, buffer: [u8; N]) -> Result<(), E> {
-        self.i2c.write(self.address, &buffer)
-    }
-
-    #[cfg(feature = "async")]
     async fn write_register<const N: usize>(&mut self, buffer: [u8; N]) -> Result<(), E> {
         self.i2c.write(self.address, &buffer).await
     }


### PR DESCRIPTION
Since sync and async code are almost identical, we should use [`maybe_async_cfg`](https://crates.io/crates/maybe-async-cfg/) to avoid *quasi* duplicate code. 