### PR TITLE
use embedded-hal 1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ std = []
 async = ["dep:embedded-hal-async"]
 
 [dependencies]
-embedded-hal = "1.0.0-rc.3"
-embedded-hal-async = { version = "=1.0.0-rc.3", optional = true }
+embedded-hal = "1.0"
+embedded-hal-async = { version = "1.0", optional = true }
 bitfield = "0.14.0"
 maybe-async-cfg = "0.2.3"


### PR DESCRIPTION
Use `embedded-hal 1.0` 🥳.

PS: new cargo release should be created after this is merged.